### PR TITLE
feat: implementar calendário completo com eventos

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,29 +1,60 @@
 import React, { useEffect, useState } from 'react';
 import { db } from '../firebase';
-import { collection, query, where, getDocs, addDoc } from 'firebase/firestore';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  addDoc,
+  deleteDoc,
+  doc,
+  updateDoc
+} from 'firebase/firestore';
+
+const MESES = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro'
+];
 
 function Calendar() {
+  const [dataAtual, setDataAtual] = useState(new Date());
   const [eventos, setEventos] = useState([]);
+  const [dataEvento, setDataEvento] = useState('');
   const [descricao, setDescricao] = useState('');
-  const [diaSelecionado, setDiaSelecionado] = useState(null);
+  const [dataModal, setDataModal] = useState(null);
 
-  const mes = 7; // Agosto (base 0)
-  const ano = 2025;
+  const ano = dataAtual.getFullYear();
+  const mes = dataAtual.getMonth();
 
   const carregarEventos = async () => {
-    const q = query(collection(db, 'eventos'),
+    const q = query(
+      collection(db, 'eventos'),
       where('mes', '==', mes + 1),
-      where('ano', '==', ano));
+      where('ano', '==', ano)
+    );
     const snapshot = await getDocs(q);
-    const data = snapshot.docs.map(doc => doc.data());
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
     setEventos(data);
   };
+
+  useEffect(() => {
+    carregarEventos();
+  }, [mes, ano]);
 
   const diasNoMes = new Date(ano, mes + 1, 0).getDate();
   const primeiroDia = new Date(ano, mes, 1).getDay();
   const semanas = [];
   let semana = new Array(primeiroDia).fill(null);
-
   for (let dia = 1; dia <= diasNoMes; dia++) {
     semana.push(dia);
     if (semana.length === 7) {
@@ -31,42 +62,108 @@ function Calendar() {
       semana = [];
     }
   }
-  if (semana.length > 0) semanas.push(semana);
+  if (semana.length > 0) {
+    while (semana.length < 7) semana.push(null);
+    semanas.push(semana);
+  }
+
+  const eventosPorDia = eventos.reduce((acc, ev) => {
+    acc[ev.dia] = acc[ev.dia] ? [...acc[ev.dia], ev] : [ev];
+    return acc;
+  }, {});
 
   const handleAdd = async (e) => {
     e.preventDefault();
-    if (!descricao || !diaSelecionado) return;
+    if (!dataEvento || !descricao) return;
+    const d = new Date(dataEvento);
     await addDoc(collection(db, 'eventos'), {
-      dia: diaSelecionado,
-      descricao,
-      mes: mes + 1,
-      ano
+      data: dataEvento,
+      dia: d.getDate(),
+      mes: d.getMonth() + 1,
+      ano: d.getFullYear(),
+      descricao
     });
+    setDataEvento('');
     setDescricao('');
-    setDiaSelecionado(null);
     carregarEventos();
   };
 
-  useEffect(() => {
-    carregarEventos();
-  }, []);
+  const abrirModal = (dia) => {
+    const data = `${ano}-${String(mes + 1).padStart(2, '0')}-${String(dia).padStart(2, '0')}`;
+    setDataModal(data);
+  };
+
+  const fecharModal = () => setDataModal(null);
+
+  const removerEvento = async (id) => {
+    if (window.confirm('Remover evento?')) {
+      await deleteDoc(doc(db, 'eventos', id));
+      carregarEventos();
+    }
+  };
+
+  const editarEvento = async (ev) => {
+    const nova = window.prompt('Nova descrição', ev.descricao);
+    if (nova && nova.trim()) {
+      await updateDoc(doc(db, 'eventos', ev.id), { descricao: nova.trim() });
+      carregarEventos();
+    }
+  };
+
+  const exportarCSV = () => {
+    const linhas = [
+      ['data', 'descricao'],
+      ...eventos.map((ev) => [ev.data, ev.descricao])
+    ];
+    const csv = linhas.map((l) => l.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'eventos.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const datasAgrupadas = eventos.reduce((acc, ev) => {
+    acc[ev.data] = acc[ev.data] ? [...acc[ev.data], ev] : [ev];
+    return acc;
+  }, {});
+  const datasOrdenadas = Object.keys(datasAgrupadas).sort();
 
   return (
     <div className="calendario">
-      <h2>Agosto 2025</h2>
+      <div className="header">
+        <button onClick={() => setDataAtual(new Date(ano, mes - 1, 1))}>&lt;</button>
+        <h2>
+          {MESES[mes]} {ano}
+        </h2>
+        <button onClick={() => setDataAtual(new Date(ano, mes + 1, 1))}>&gt;</button>
+      </div>
+
       <table>
         <thead>
           <tr>
-            <th>D</th><th>S</th><th>T</th><th>Q</th><th>Q</th><th>S</th><th>S</th>
+            <th>D</th>
+            <th>S</th>
+            <th>T</th>
+            <th>Q</th>
+            <th>Q</th>
+            <th>S</th>
+            <th>S</th>
           </tr>
         </thead>
         <tbody>
-          {semanas.map((semana, i) => (
+          {semanas.map((sem, i) => (
             <tr key={i}>
-              {semana.map((dia, j) => (
-                <td key={j} onClick={() => setDiaSelecionado(dia)}>
+              {sem.map((dia, j) => (
+                <td
+                  key={j}
+                  className={dia && eventosPorDia[dia] ? 'has-event' : ''}
+                  onClick={() => dia && abrirModal(dia)}
+                >
                   {dia}
-                  {eventos.find(ev => ev.dia === dia) && <div className="marcado">*</div>}
+                  {dia && eventosPorDia[dia] && <span className="dot" />}
                 </td>
               ))}
             </tr>
@@ -74,19 +171,58 @@ function Calendar() {
         </tbody>
       </table>
 
-      {diaSelecionado && (
-        <form onSubmit={handleAdd}>
-          <h4>Adicionar evento no dia {diaSelecionado}</h4>
-          <input value={descricao} onChange={e => setDescricao(e.target.value)} placeholder="Descrição" />
-          <button type="submit">Salvar</button>
-        </form>
-      )}
+      <form onSubmit={handleAdd} className="form-event">
+        <input
+          type="date"
+          value={dataEvento}
+          onChange={(e) => setDataEvento(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          value={descricao}
+          onChange={(e) => setDescricao(e.target.value)}
+          placeholder="Descrição"
+          required
+        />
+        <button type="submit">Salvar</button>
+      </form>
+
+      <div className="acoes">
+        <button onClick={() => window.print()}>Imprimir calendário</button>
+        <button onClick={exportarCSV}>Exportar CSV</button>
+      </div>
 
       <ul className="eventos">
-        {eventos.map((ev, idx) => (
-          <li key={idx}>{ev.dia.toString().padStart(2, '0')} - {ev.descricao}</li>
+        {datasOrdenadas.map((data) => (
+          <li key={data}>
+            <strong>{new Date(data).toLocaleDateString('pt-BR')}</strong>
+            <ul>
+              {datasAgrupadas[data].map((ev) => (
+                <li key={ev.id}>{ev.descricao}</li>
+              ))}
+            </ul>
+          </li>
         ))}
       </ul>
+
+      {dataModal && (
+        <div className="modal-overlay" onClick={fecharModal}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h3>{new Date(dataModal).toLocaleDateString('pt-BR')}</h3>
+            <ul>
+              {(datasAgrupadas[dataModal] || []).map((ev) => (
+                <li key={ev.id}>
+                  {ev.descricao}{' '}
+                  <button onClick={() => editarEvento(ev)}>Editar</button>{' '}
+                  <button onClick={() => removerEvento(ev.id)}>Remover</button>
+                </li>
+              ))}
+            </ul>
+            <button onClick={fecharModal}>Fechar</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -11,22 +11,39 @@ h1 {
 }
 
 .calendario {
-  max-width: 600px;
+  max-width: 800px;
   margin: auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.header button {
+  background: #d30000;
+  color: #fff;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 20px;
+  margin-top: 10px;
 }
 
-td, th {
+th,
+td {
   border: 1px solid #ccc;
   width: 14.2%;
-  height: 50px;
+  height: 80px;
   text-align: center;
   vertical-align: top;
+  position: relative;
 }
 
 td:hover {
@@ -34,17 +51,103 @@ td:hover {
   cursor: pointer;
 }
 
-.marcado {
-  font-size: 1.2em;
-  color: #d30000;
+.has-event {
+  background: #ffe5e5;
 }
 
-form {
+.dot {
+  width: 6px;
+  height: 6px;
+  background: #d30000;
+  border-radius: 50%;
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.form-event {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   margin-top: 20px;
+}
+
+.form-event input {
+  flex: 1;
+  padding: 5px;
+}
+
+.form-event button {
+  background: #d30000;
+  color: #fff;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.acoes {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+}
+
+.acoes button {
+  background: #555;
+  color: #fff;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
 }
 
 .eventos {
   margin-top: 20px;
-  padding-left: 0;
   list-style: none;
+  padding: 0;
+}
+
+.eventos > li {
+  margin-bottom: 10px;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #fff;
+  padding: 20px;
+  max-width: 400px;
+  width: 90%;
+}
+
+.modal button {
+  margin-top: 10px;
+}
+
+@media (max-width: 600px) {
+  th,
+  td {
+    height: 60px;
+  }
+}
+
+@media print {
+  .form-event,
+  .acoes,
+  .modal-overlay,
+  button {
+    display: none !important;
+  }
+  body {
+    padding: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- adicionar calendário navegável integrado ao Firestore
- permitir cadastro, edição, exclusão e listagem de eventos
- exportar eventos e preparar layout para impressão

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dff169a98832e9926aab602b72288