### PR TITLE
Add printable calendar component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import Calendar from './components/Calendar';
+// import Calendar from './components/Calendar';
+import PrintableCalendars, { MESES } from './components/PrintableCalendars';
+
+// Gera calendários reais para o ano atual sem eventos
+const anoAtual = new Date().getFullYear();
+const calendariosAno = MESES.map((mes) => ({
+  mes,
+  ano: anoAtual,
+  eventos: [],
+  fasesLua: {}
+}));
 
 function App() {
   return (
     <main>
-      <h1>Calendário Catequese</h1>
-      <Calendar />
+      <h1>Calendários para Impressão</h1>
+      <PrintableCalendars calendarios={calendariosAno} />
     </main>
   );
 }

--- a/src/components/PrintableCalendars.css
+++ b/src/components/PrintableCalendars.css
@@ -1,0 +1,120 @@
+.print-wrapper {
+  font-family: sans-serif;
+}
+
+.pagina-calendarios {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  page-break-after: always;
+}
+
+.calendario-print {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.mes-header {
+  background: #b30000;
+  color: #fff;
+  text-align: center;
+  padding: 0.2rem 0;
+}
+
+.mes-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.mes-header .ano {
+  font-weight: normal;
+}
+
+.mes-tabela {
+  width: 100%;
+  border-collapse: collapse;
+  flex: 1;
+}
+
+.mes-tabela th,
+.mes-tabela td {
+  border: 1px solid #999;
+  width: calc(100% / 7);
+  height: 1.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+}
+
+.mes-tabela th {
+  background: #f2f2f2;
+  font-weight: normal;
+}
+
+.mes-tabela th.domingo {
+  background: #b30000;
+  color: #fff;
+}
+
+.mes-tabela td.domingo {
+  color: #b30000;
+}
+
+.mes-tabela td.has-evento {
+  color: #b30000;
+  font-weight: bold;
+}
+
+.mes-tabela .fase-lua {
+  display: block;
+  font-size: 0.6rem;
+  line-height: 1;
+}
+
+.lista-eventos {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0;
+  font-size: 0.7rem;
+}
+
+.lista-eventos li {
+  margin-bottom: 0.2rem;
+}
+
+.lista-eventos .dia {
+  color: #b30000;
+  font-weight: bold;
+  margin-right: 0.3rem;
+}
+
+.fases-lua {
+  margin-top: auto;
+  font-size: 0.6rem;
+}
+
+.fase-item {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.fase-item .dia {
+  color: #b30000;
+  font-weight: bold;
+}
+
+@media print {
+  @page {
+    size: A4 landscape;
+    margin: 10mm;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  .pagina-calendarios {
+    gap: 0;
+  }
+}

--- a/src/components/PrintableCalendars.jsx
+++ b/src/components/PrintableCalendars.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import './PrintableCalendars.css';
+
+export const MESES = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro'
+];
+
+const SEMANA = ['D', 'S', 'T', 'Q', 'Q', 'S', 'S'];
+
+function chunk(arr, size) {
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function gerarSemanas(ano, mesIndex) {
+  const diasNoMes = new Date(ano, mesIndex + 1, 0).getDate();
+  const primeiroDia = new Date(ano, mesIndex, 1).getDay();
+  const semanas = [];
+  let semana = new Array(primeiroDia).fill(null);
+  for (let dia = 1; dia <= diasNoMes; dia++) {
+    semana.push(dia);
+    if (semana.length === 7) {
+      semanas.push(semana);
+      semana = [];
+    }
+  }
+  if (semana.length > 0) {
+    while (semana.length < 7) semana.push(null);
+    semanas.push(semana);
+  }
+  return semanas;
+}
+
+function iconForPhase(fase) {
+  const icons = {
+    CRESC: '🌓',
+    CHEIA: '🌕',
+    MING: '🌗',
+    NOVA: '🌑'
+  };
+  return icons[fase] || '';
+}
+
+function labelForPhase(fase) {
+  const labels = {
+    CRESC: 'Crescente',
+    CHEIA: 'Cheia',
+    MING: 'Minguante',
+    NOVA: 'Nova'
+  };
+  return labels[fase] || '';
+}
+
+function Calendario({ data }) {
+  const mesIndex = MESES.indexOf(data.mes);
+  const semanas = gerarSemanas(data.ano, mesIndex);
+
+  const eventosMap = data.eventos.reduce((acc, ev) => {
+    acc[ev.dia] = acc[ev.dia] ? [...acc[ev.dia], ev] : [ev];
+    return acc;
+  }, {});
+
+  const fases = data.fasesLua || {};
+
+  return (
+    <div className="calendario-print" style={{ pageBreakInside: 'avoid' }}>
+      <header className="mes-header">
+        <h2>{data.mes} <span className="ano">{data.ano}</span></h2>
+      </header>
+      <table className="mes-tabela">
+        <thead>
+          <tr>
+            {SEMANA.map((d, i) => (
+              <th key={i} className={i === 0 ? 'domingo' : ''}>{d}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {semanas.map((sem, i) => (
+            <tr key={i}>
+              {sem.map((dia, j) => {
+                const isSunday = j === 0;
+                const hasEvent = dia && eventosMap[dia];
+                const fase = dia && fases[dia];
+                const classes = [];
+                if (isSunday) classes.push('domingo');
+                if (hasEvent) classes.push('has-evento');
+                return (
+                  <td key={j} className={classes.join(' ')}>
+                    {dia}
+                    {fase && <span className="fase-lua">{iconForPhase(fase)}</span>}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <ul className="lista-eventos">
+        {data.eventos.map((ev) => (
+          <li key={ev.dia}>
+            <span className="dia">{String(ev.dia).padStart(2, '0')}</span>
+            <span className="titulo">{ev.titulo}</span>
+            {ev.subtitulo && <span className="subtitulo"> - {ev.subtitulo}</span>}
+          </li>
+        ))}
+      </ul>
+      <div className="fases-lua">
+        {Object.entries(fases).map(([dia, fase]) => (
+          <div key={dia} className="fase-item">
+            <span className="dia">{String(dia).padStart(2, '0')}</span>
+            <span className="icone">{iconForPhase(fase)}</span>
+            <span className="label">{labelForPhase(fase)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function PrintableCalendars({ calendarios }) {
+  const pages = chunk(calendarios, 3);
+  return (
+    <div className="print-wrapper">
+      {pages.map((grupo, i) => (
+        <div key={i} className="pagina-calendarios">
+          {grupo.map((cal) => (
+            <Calendario key={`${cal.mes}-${cal.ano}`} data={cal} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build `PrintableCalendars` component that renders months in a three-column layout ready for A4 landscape printing
- add example usage in `App.jsx`
- generate calendar data for the current year instead of hard-coded examples

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e0a91f904832e8d1e7aabcf2bced2